### PR TITLE
Release 0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL homepage="http://github.com/primer/actions/tree/master/deploy"
 LABEL maintainer="GitHub Design Systems <design-systems@github.com>"
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends git
+  apt-get install -y --no-install-recommends git jq
 
 WORKDIR /primer-publish
 COPY . .

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ This [GitHub Action][github actions] publishes to npm with the following convent
 1. If we're on a `release-<version>` branch, we publish a release candidate to the `next` npm dist-tag with the version in the form: `<version>-rc.<sha>`
 1. Otherwise, we publish a "canary" release, which has a version in the form: `0.0.0-<sha>`.
 
+Also:
+
+* If the version in `package.json` is already published, we exit with a `78` code, which is Actions-speak for "neutral".
+* On the `master` branch, we push the version commits back to GitHub via git.
+
 ## Status checks
 Two [status checks] will be listed for this action in your checks: **publish** is the action's check, and **publish <package-name>** is a [commit status] created by the action that reports the URL and links to `unpkg.com` via "Details":
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,9 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
 fi
 
 # configure git with sensible defaults
-git config --global user.email "${GIT_USER_EMAIL:-design-systems@github.com}"
-git config --global user.name "${GIT_USER_NAME:-primer-bot}"
+git config --global user.email "${GIT_USER_EMAIL:-$(jq -r .pusher.email $GITHUB_EVENT_PATH)}"
+git config --global user.name "${GIT_USER_NAME:-$(jq -r .pusher.name $GITHUB_EVENT_PATH)}"
+# then print out our config
+git config --list
 
 sh -c "/primer-publish/cli.js $*"

--- a/src/__tests__/publish.js
+++ b/src/__tests__/publish.js
@@ -99,7 +99,7 @@ describe('publish()', () => {
       expect(execa).toHaveBeenCalledTimes(3)
       expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['view', `pkg@${version}`, 'version'], {stderr: 'inherit'})
       expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['publish', '--tag', 'latest', '--access', 'public'], execOpts)
-      expect(execa).toHaveBeenNthCalledWith(3, 'git', ['push', '--tags', 'HEAD'], execOpts)
+      expect(execa).toHaveBeenNthCalledWith(3, 'git', ['push', '--tags', 'origin', 'master'], execOpts)
     })
   })
 

--- a/src/__tests__/publish.js
+++ b/src/__tests__/publish.js
@@ -48,14 +48,6 @@ describe('publish()', () => {
     return publish().then(() => {
       expect(execa).toHaveBeenCalledTimes(2)
       expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['version', version], execOpts)
-      /*
-      expect(execa).toHaveBeenNthCalledWith(
-        2,
-        'git',
-        ['commit', '-m', `chore: npm version ${version}`, 'package*.json'],
-        execOpts
-      )
-      */
       expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['publish', '--tag', 'canary', '--access', 'public'], execOpts)
     })
   })
@@ -73,14 +65,6 @@ describe('publish()', () => {
     return publish().then(() => {
       expect(execa).toHaveBeenCalledTimes(2)
       expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['version', version], execOpts)
-      /*
-      expect(execa).toHaveBeenNthCalledWith(
-        2,
-        'git',
-        ['commit', '-m', `chore: npm version ${version}`, 'package*.json'],
-        execOpts
-      )
-      */
       expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['publish', '--tag', 'next', '--access', 'public'], execOpts)
     })
   })

--- a/src/publish.js
+++ b/src/publish.js
@@ -50,13 +50,13 @@ module.exports = function publish(options = {}, npmArgs = []) {
     )
     .then(() => {
       if (isLatest) {
-        const context = 'git push'
+        const context = 'publish/git'
         return publishStatus({
           context,
           state: 'pending',
-          description: 'Pushing HEAD + tags...'
+          description: `git push --tags origin ${branch}`
         })
-          .then(() => run('git', ['push', '--tags', 'HEAD'], execOpts))
+          .then(() => run('git', ['push', '--tags', 'origin', branch], execOpts))
           .then(() =>
             publishStatus({
               context,

--- a/src/publish.js
+++ b/src/publish.js
@@ -8,13 +8,15 @@ module.exports = function publish(options = {}, npmArgs = []) {
     throw new Error(`You must set the NPM_AUTH_TOKEN environment variable`)
   }
 
-  const context = getContext(options)
-  const {name, version, tag, packageJson} = context
-  const isLatest = packageJson.version === version
-  const {branch, sha} = meta.git
-
   const run = options.dryRun ? runDry : require('execa')
   const execOpts = {stdio: 'inherit'}
+
+  const context = getContext(options)
+  const {name, version, tag, packageJson} = context
+  const {branch, sha} = meta.git
+
+  // this is true if we think we're publishing the version that's in git
+  const isLatest = packageJson.version === version
 
   return Promise.resolve()
     .then(() => {
@@ -54,7 +56,7 @@ module.exports = function publish(options = {}, npmArgs = []) {
         return publishStatus({
           context,
           state: 'pending',
-          description: `git push --tags origin ${branch}`
+          description: `Running: git push --tags origin ${branch}`
         })
           .then(() => run('git', ['push', '--tags', 'origin', branch], execOpts))
           .then(() =>


### PR DESCRIPTION
The publish step failed on `master` when merging #2, so this is an attempt to fix it. Here's what is changing:

1. Instead of `git push --tags HEAD`, we call `git push --tags origin $branch`, which _should_ do the right thing.
1. In the entrypoint script we configure the git `user.email` and `user.name` using the corresponding fields from the JSON event payload's `pusher` object, which looks like: `{"email": "<email>", "name": "<username>"}`.