### PR TITLE
Release 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/publish",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@octokit/rest": "^16.15.0",
     "action-status": "^0.1.1",
     "github-action-meta": "^0.1.2",
     "yargs": "^12.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/publish",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Publish Primer projects to npm with GitHub Design Systems conventions",
   "keywords": [
     "primer",

--- a/src/__tests__/publish.js
+++ b/src/__tests__/publish.js
@@ -80,11 +80,11 @@ describe('publish()', () => {
       'package.json': {name: 'pkg', version}
     })
     return publish().then(() => {
-      expect(execa).toHaveBeenCalledTimes(4)
+      expect(execa).toHaveBeenCalledTimes(2)
       expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['view', `pkg@${version}`, 'version'], {stderr: 'inherit'})
       expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['publish', '--tag', 'latest', '--access', 'public'], execOpts)
-      expect(execa).toHaveBeenNthCalledWith(3, 'git', ['tag', `v${version}`], execOpts)
-      expect(execa).toHaveBeenNthCalledWith(4, 'git', ['push', '--tags', 'origin'], execOpts)
+      // expect(execa).toHaveBeenNthCalledWith(3, 'git', ['tag', `v${version}`], execOpts)
+      // expect(execa).toHaveBeenNthCalledWith(4, 'git', ['push', '--tags', 'origin'], execOpts)
     })
   })
 


### PR DESCRIPTION
This scraps the original approach of using the `git` binary to push a tag back to GitHub, and uses the API via Octokit instead.