### PR TITLE
Fix: pass tag to octokit :facepalm:

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/publish",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Publish Primer projects to npm with GitHub Design Systems conventions",
   "keywords": [
     "primer",

--- a/src/publish.js
+++ b/src/publish.js
@@ -78,6 +78,7 @@ module.exports = function publish(options = {}, npmArgs = []) {
                 owner: repo.owner,
                 repo: repo.name,
                 object: sha,
+                tag,
                 message: `chore: tag ${tag}`
               })
             )


### PR DESCRIPTION
Well, #5 published to npm but [the publish action failed](https://github.com/primer/publish/runs/59995277) because I forgot the `tag` parameter in my API call. This should sort that out.