### PR TITLE
Release 1.0.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+git-tag-version=false

--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@
 This [GitHub Action][github actions] publishes to npm with the following conventions:
 
 1. If we're on the `master` branch, the `version` field is used as-is and we just run `npm publish --access public`.
-1. If we're on a `release-<version>` branch, we publish a release candidate to the `next` npm dist-tag with the version in the form: `<version>-rc.<sha>`
+    * After publishing a new version on the `master` branch, we tag the commit SHA with `v{version}` via the GitHub API.
+    * If the version in `package.json` is already published, we exit with a `78` code, which is Actions-speak for "neutral".
+1. If we're on a `release-<version>` branch, we publish a release candidate to the `next` npm dist-tag with the version in the form: `<version>-rc.<sha>`.
+    * A [status check][status checks] is created with the context `npm version` noting whether the `version` field in `package.json` matches the `<version>` portion of the branch. If it doesn't, the check's status is marked as pending.
 1. Otherwise, we publish a "canary" release, which has a version in the form: `0.0.0-<sha>`.
-
-Also:
-
-* If the version in `package.json` is already published, we exit with a `78` code, which is Actions-speak for "neutral".
-* On the `master` branch, we push the version commits back to GitHub via git.
 
 ## Status checks
 Two [status checks] will be listed for this action in your checks: **publish** is the action's check, and **publish {package-name}** is a [commit status] created by the action that reports the version published and links to `unpkg.com` via "Details":

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ This [GitHub Action][github actions] publishes to npm with the following convent
 1. Otherwise, we publish a "canary" release, which has a version in the form: `0.0.0-<sha>`.
 
 ## Status checks
-Two [status checks] will be listed for this action in your checks: **publish** is the action's check, and **publish {package-name}** is a [commit status] created by the action that reports the version published and links to `unpkg.com` via "Details":
+Depending on the branch, a series of [statuses][status checks] will be created by this action in your checks: **publish** is the action's check, and **publish {package-name}** is a [commit status] created by the action that reports the version published and links to `unpkg.com` via "Details":
 
 ![image](https://user-images.githubusercontent.com/113896/52375286-23368980-2a14-11e9-8974-062a3e45a846.png)
+
+If you're on a release branch (`release-<version>`) and the `<version>` portion of the branch name doesn't match the `version` field in `package.json`, you'll get a pending status reminding you to update it:
+
+![image](https://user-images.githubusercontent.com/113896/52388530-b63ae800-2a43-11e9-92ef-14ec9459c109.png)
+
 
 ## Usage
 To use this action in your own workflow, add the following snippet to your `.github/main.workflow` file:
@@ -27,9 +32,9 @@ action "publish" {
 }
 ```
 
-**You will need to provide an npm access token with publish permissions via the `NPM_AUTH_TOKEN` secret in the Actions visual editor** if you haven't already.
+**You will need to provide an npm access token with publish permissions via the `NPM_AUTH_TOKEN` secret in the Actions visual editor** if you haven't already. The `GITHUB_TOKEN` secret is also required to create tags after releasing on the master branch.
 
-To avoid racking up failed publish actions, we suggest that you place this action after any linting and test actions.
+We suggest that you place this action after any linting and/or testing actions to catch as many errors as possible before publishing.
 
 ## npm CLI arguments
 It's possible to pass additional arguments to `npm` via the `args` field in your workflow action. Because the `primer-publish` CLI accepts options of its own (such as `--dry-run`), you need to prefix any `npm` arguments with `--`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/publish",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/publish",
-  "version": "0.2.5",
+  "version": "1.0.0",
   "description": "Publish Primer projects to npm with GitHub Design Systems conventions",
   "keywords": [
     "primer",

--- a/src/publish.js
+++ b/src/publish.js
@@ -85,7 +85,8 @@ module.exports = function publish(options = {}, npmArgs = []) {
               publishStatus(context, {
                 context: tagContext,
                 state: 'success',
-                description: `Tagged ${sha.substr(0, 7)} as "${tag}"`
+                description: `Tagged ${sha.substr(0, 7)} as "${tag}"`,
+                url: `https://github.com/${repo}/releases/new?tag=${tag}`
               })
             )
         }


### PR DESCRIPTION
This is mostly a symbolic release marking the repo as ready to use. In the tin:

1. The tag status sets the URL of the "Details" link to where you create a new GitHub release.
1. The docs have been updated to reflect what actually happens. 😊 