### PR TITLE
Add --dir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 This [GitHub Action][github actions] publishes to npm with the following conventions:
 
 1. If we're on the `master` branch, the `version` field is used as-is and we just run `npm publish --access public`.
-    * After publishing a new version on the `master` branch, we tag the commit SHA with `v{version}` via the GitHub API.
-    * If the version in `package.json` is already published, we exit with a `78` code, which is Actions-speak for "neutral".
+   - After publishing a new version on the `master` branch, we tag the commit SHA with `v{version}` via the GitHub API.
+   - If the version in `package.json` is already published, we exit with a `78` code, which is Actions-speak for "neutral".
 1. If we're on a `release-<version>` branch, we publish a release candidate to the `next` npm dist-tag with the version in the form: `<version>-rc.<sha>`.
-    * A [status check][status checks] is created with the context `npm version` noting whether the `version` field in `package.json` matches the `<version>` portion of the branch. If it doesn't, the check's status is marked as pending.
+   - A [status check][status checks] is created with the context `npm version` noting whether the `version` field in `package.json` matches the `<version>` portion of the branch. If it doesn't, the check's status is marked as pending.
 1. Otherwise, we publish a "canary" release, which has a version in the form: `0.0.0-<sha>`.
 
 ## Status checks
+
 Depending on the branch, a series of [statuses][status checks] will be created by this action in your checks: **publish** is the action's check, and **publish {package-name}** is a [commit status] created by the action that reports the version published and links to `unpkg.com` via "Details":
 
 ![image](https://user-images.githubusercontent.com/113896/52375286-23368980-2a14-11e9-8974-062a3e45a846.png)
@@ -18,8 +19,8 @@ If you're on a release branch (`release-<version>`) and the `<version>` portion 
 
 ![image](https://user-images.githubusercontent.com/113896/52388530-b63ae800-2a43-11e9-92ef-14ec9459c109.png)
 
-
 ## Usage
+
 To use this action in your own workflow, add the following snippet to your `.github/main.workflow` file:
 
 ```hcl
@@ -54,12 +55,11 @@ action "publish" {
 }
 ```
 
-
-### `--folder=<path>`
+### `--dir=<path>`
 
 Default: `.`
 
-Accepts a path to the folder that contains the `package.json` to publish.
+Accepts a path to the directory that contains the `package.json` to publish.
 
 #### Example
 
@@ -67,11 +67,12 @@ Accepts a path to the folder that contains the `package.json` to publish.
 action "publish" {
   uses = "primer/publish@master"
   secrets = ["GITHUB_TOKEN", "NPM_AUTH_TOKEN"]
-  args = "--folder=packages/example"
+  args = "--dir=packages/example"
 }
 ```
 
 ## npm CLI arguments
+
 It's possible to pass additional arguments to `npm` via the `args` field in your workflow action. Because the `primer-publish` CLI accepts options of its own (such as `--dry-run`), you need to prefix any `npm` arguments with `--`:
 
 ```diff

--- a/README.md
+++ b/README.md
@@ -36,6 +36,41 @@ action "publish" {
 
 We suggest that you place this action after any linting and/or testing actions to catch as many errors as possible before publishing.
 
+## Options
+
+### `--dry-run`
+
+Default: `false`
+
+Does everything publish would do except actually publishing to the registry. Reports the details of what would have been published.
+
+#### Example
+
+```hcl
+action "publish" {
+  uses = "primer/publish@master"
+  secrets = ["GITHUB_TOKEN", "NPM_AUTH_TOKEN"]
+  args = "--dry-run"
+}
+```
+
+
+### `--folder=<path>`
+
+Default: `.`
+
+Accepts a path to the folder that contains the `package.json` to publish.
+
+#### Example
+
+```hcl
+action "publish" {
+  uses = "primer/publish@master"
+  secrets = ["GITHUB_TOKEN", "NPM_AUTH_TOKEN"]
+  args = "--folder=packages/example"
+}
+```
+
 ## npm CLI arguments
 It's possible to pass additional arguments to `npm` via the `args` field in your workflow action. Because the `primer-publish` CLI accepts options of its own (such as `--dry-run`), you need to prefix any `npm` arguments with `--`:
 

--- a/cli.js
+++ b/cli.js
@@ -6,6 +6,11 @@ const yargs = require('yargs')
     describe: 'Print what will be done without doing it',
     type: 'boolean'
   })
+  .option('folder', {
+    describe: 'A folder containing a package.json file',
+    type: 'string',
+    default: '.'
+  })
   .alias('help', 'h')
 
 const options = yargs.argv

--- a/cli.js
+++ b/cli.js
@@ -6,8 +6,8 @@ const yargs = require('yargs')
     describe: 'Print what will be done without doing it',
     type: 'boolean'
   })
-  .option('folder', {
-    describe: 'A folder containing a package.json file',
+  .option('dir', {
+    describe: 'Path to the directory that contains the package.json to publish',
     type: 'string',
     default: '.'
   })

--- a/src/__tests__/context.js
+++ b/src/__tests__/context.js
@@ -27,6 +27,10 @@ describe('getContext()', () => {
     expect(() => getContext()).toThrow()
   })
 
+  it('throws if package.json does not exist in given folder', () => {
+    expect(() => getContext({folder: 'foo/bar'})).toThrow()
+  })
+
   it('throws if "private": true in package.json', () => {
     mockFiles({'package.json': {private: true}})
     expect(() => getContext()).toThrow()
@@ -105,6 +109,18 @@ describe('getContext()', () => {
     mockEnv({GITHUB_REF: 'refs/heads/master'})
     return getContext().then(context => {
       expect(context.version).toBe(version)
+      expect(context.tag).toBe('latest')
+    })
+  })
+
+  it('respects "folder" option', () => {
+    mockFiles({
+      'foo/bar/package.json': {name: 'example', version: '1.0.0'}
+    })
+    mockEnv({GITHUB_REF: 'refs/heads/master'})
+    return getContext({folder: 'foo/bar'}).then(context => {
+      expect(context.name).toBe('example')
+      expect(context.version).toBe('1.0.0')
       expect(context.tag).toBe('latest')
     })
   })

--- a/src/__tests__/context.js
+++ b/src/__tests__/context.js
@@ -27,8 +27,8 @@ describe('getContext()', () => {
     expect(() => getContext()).toThrow()
   })
 
-  it('throws if package.json does not exist in given folder', () => {
-    expect(() => getContext({folder: 'foo/bar'})).toThrow()
+  it('throws if package.json does not exist in given directory', () => {
+    expect(() => getContext({dir: 'foo/bar'})).toThrow()
   })
 
   it('throws if "private": true in package.json', () => {
@@ -113,12 +113,12 @@ describe('getContext()', () => {
     })
   })
 
-  it('respects "folder" option', () => {
+  it('respects "dir" option', () => {
     mockFiles({
       'foo/bar/package.json': {name: 'example', version: '1.0.0'}
     })
     mockEnv({GITHUB_REF: 'refs/heads/master'})
-    return getContext({folder: 'foo/bar'}).then(context => {
+    return getContext({dir: 'foo/bar'}).then(context => {
       expect(context.name).toBe('example')
       expect(context.version).toBe('1.0.0')
       expect(context.tag).toBe('latest')

--- a/src/__tests__/publish.js
+++ b/src/__tests__/publish.js
@@ -46,10 +46,12 @@ describe('publish()', () => {
     })
     const version = '0.0.0-deadfad'
     return publish().then(() => {
-      expect(execa).toHaveBeenCalledTimes(2)
-      expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['version', version], execOpts)
+      expect(execa).toHaveBeenCalledTimes(4)
+      expect(execa).toHaveBeenNthCalledWith(1, 'pushd', ['.'], execOpts)
+      expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['version', version], execOpts)
+      expect(execa).toHaveBeenNthCalledWith(3, 'popd', [], execOpts)
       expect(execa).toHaveBeenNthCalledWith(
-        2,
+        4,
         'npm',
         ['publish', '.', '--tag', 'canary', '--access', 'public'],
         execOpts
@@ -68,9 +70,11 @@ describe('publish()', () => {
     })
     const version = '2.0.0-rc.deadfad'
     return publish().then(() => {
-      expect(execa).toHaveBeenCalledTimes(2)
-      expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['version', version], execOpts)
-      expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['publish', '.', '--tag', 'next', '--access', 'public'], execOpts)
+      expect(execa).toHaveBeenCalledTimes(4)
+      expect(execa).toHaveBeenNthCalledWith(1, 'pushd', ['.'], execOpts)
+      expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['version', version], execOpts)
+      expect(execa).toHaveBeenNthCalledWith(3, 'popd', [], execOpts)
+      expect(execa).toHaveBeenNthCalledWith(4, 'npm', ['publish', '.', '--tag', 'next', '--access', 'public'], execOpts)
     })
   })
 

--- a/src/__tests__/publish.js
+++ b/src/__tests__/publish.js
@@ -118,12 +118,12 @@ describe('publish()', () => {
     mockFiles({
       'package.json': {name: 'pkg', version: '1.0.0'}
     })
-    return publish({dryRun: true, folder: '.'}).then(() => {
+    return publish({dryRun: true, dir: '.'}).then(() => {
       expect(execa).toHaveBeenCalledTimes(0)
     })
   })
 
-  it('respects "folder" option on master', () => {
+  it('respects "dir" option on master', () => {
     const version = '1.1.0'
     mockEnv({
       GITHUB_REF: 'refs/heads/master',
@@ -133,7 +133,7 @@ describe('publish()', () => {
     mockFiles({
       'foo/bar/package.json': {name: 'pkg', version}
     })
-    return publish({folder: 'foo/bar'}).then(() => {
+    return publish({dir: 'foo/bar'}).then(() => {
       expect(execa).toHaveBeenCalledTimes(2)
       expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['view', `pkg@${version}`, 'version'], {stderr: 'inherit'})
       expect(execa).toHaveBeenNthCalledWith(
@@ -145,7 +145,7 @@ describe('publish()', () => {
     })
   })
 
-  it('respects "folder" option on a release branch', () => {
+  it('respects "dir" option on a release branch', () => {
     mockEnv({
       GITHUB_REF: 'refs/heads/release-2.0.0',
       GITHUB_SHA: 'deadfad',
@@ -155,7 +155,7 @@ describe('publish()', () => {
       'foo/bar/package.json': {name: 'pkg', version: '1.0.0'}
     })
     const version = '2.0.0-rc.deadfad'
-    return publish({folder: 'foo/bar'}).then(() => {
+    return publish({dir: 'foo/bar'}).then(() => {
       expect(execa).toHaveBeenCalledTimes(2)
       expect(execa).toHaveBeenNthCalledWith(
         1,

--- a/src/__tests__/publish.js
+++ b/src/__tests__/publish.js
@@ -48,7 +48,12 @@ describe('publish()', () => {
     return publish().then(() => {
       expect(execa).toHaveBeenCalledTimes(2)
       expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['version', version], execOpts)
-      expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['publish', '--tag', 'canary', '--access', 'public'], execOpts)
+      expect(execa).toHaveBeenNthCalledWith(
+        2,
+        'npm',
+        ['publish', '.', '--tag', 'canary', '--access', 'public'],
+        execOpts
+      )
     })
   })
 
@@ -65,7 +70,7 @@ describe('publish()', () => {
     return publish().then(() => {
       expect(execa).toHaveBeenCalledTimes(2)
       expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['version', version], execOpts)
-      expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['publish', '--tag', 'next', '--access', 'public'], execOpts)
+      expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['publish', '.', '--tag', 'next', '--access', 'public'], execOpts)
     })
   })
 
@@ -82,7 +87,12 @@ describe('publish()', () => {
     return publish().then(() => {
       expect(execa).toHaveBeenCalledTimes(2)
       expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['view', `pkg@${version}`, 'version'], {stderr: 'inherit'})
-      expect(execa).toHaveBeenNthCalledWith(2, 'npm', ['publish', '--tag', 'latest', '--access', 'public'], execOpts)
+      expect(execa).toHaveBeenNthCalledWith(
+        2,
+        'npm',
+        ['publish', '.', '--tag', 'latest', '--access', 'public'],
+        execOpts
+      )
       // expect(execa).toHaveBeenNthCalledWith(3, 'git', ['tag', `v${version}`], execOpts)
       // expect(execa).toHaveBeenNthCalledWith(4, 'git', ['push', '--tags', 'origin'], execOpts)
     })
@@ -99,6 +109,28 @@ describe('publish()', () => {
     })
     return publish({dryRun: true}).then(() => {
       expect(execa).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  it('respects "folder" option', () => {
+    const version = '1.1.0'
+    mockEnv({
+      GITHUB_REF: 'refs/heads/master',
+      GITHUB_SHA: 'deadfad',
+      NPM_AUTH_TOKEN: 'secret'
+    })
+    mockFiles({
+      'foo/bar/package.json': {name: 'pkg', version}
+    })
+    return publish({folder: 'foo/bar'}).then(() => {
+      expect(execa).toHaveBeenCalledTimes(2)
+      expect(execa).toHaveBeenNthCalledWith(1, 'npm', ['view', `pkg@${version}`, 'version'], {stderr: 'inherit'})
+      expect(execa).toHaveBeenNthCalledWith(
+        2,
+        'npm',
+        ['publish', 'foo/bar', '--tag', 'latest', '--access', 'public'],
+        execOpts
+      )
     })
   })
 

--- a/src/context.js
+++ b/src/context.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const meta = require('github-action-meta')
 const readJSON = require('./read-json')
 
@@ -11,10 +12,10 @@ const CANARY_VERSION = '0.0.0'
 const CANARY_TAG = 'canary'
 
 // eslint-disable-next-line no-unused-vars
-module.exports = function getContext(options) {
-  const packageJson = readJSON('package.json')
+module.exports = function getContext({folder = '.'} = {}) {
+  const packageJson = readJSON(path.join(folder, 'package.json'))
   if (!packageJson) {
-    throw new Error(`Unable to read package.json in ${process.cwd()}!`)
+    throw new Error(`Unable to read package.json in ${path.join(process.cwd(), folder)}!`)
   }
   const {name} = packageJson
 

--- a/src/context.js
+++ b/src/context.js
@@ -11,10 +11,10 @@ const RELEASE_CANDIDATE_TAG = 'next'
 const CANARY_VERSION = '0.0.0'
 const CANARY_TAG = 'canary'
 
-module.exports = function getContext({folder = '.'} = {}) {
-  const packageJson = readJSON(path.join(folder, 'package.json'))
+module.exports = function getContext({dir = '.'} = {}) {
+  const packageJson = readJSON(path.join(dir, 'package.json'))
   if (!packageJson) {
-    throw new Error(`Unable to read package.json in ${path.join(process.cwd(), folder)}!`)
+    throw new Error(`Unable to read package.json in ${path.join(process.cwd(), dir)}!`)
   }
   const {name} = packageJson
 

--- a/src/context.js
+++ b/src/context.js
@@ -11,7 +11,6 @@ const RELEASE_CANDIDATE_TAG = 'next'
 const CANARY_VERSION = '0.0.0'
 const CANARY_TAG = 'canary'
 
-// eslint-disable-next-line no-unused-vars
 module.exports = function getContext({folder = '.'} = {}) {
   const packageJson = readJSON(path.join(folder, 'package.json'))
   if (!packageJson) {

--- a/src/publish.js
+++ b/src/publish.js
@@ -4,7 +4,7 @@ const actionStatus = require('action-status')
 const getContext = require('./context')
 const runDry = require('./run-dry')
 
-module.exports = function publish(options = {folder: '.'}, npmArgs = []) {
+module.exports = function publish(options = {dir: '.'}, npmArgs = []) {
   if (!process.env.NPM_AUTH_TOKEN) {
     throw new Error(`You must set the NPM_AUTH_TOKEN environment variable`)
   }
@@ -40,7 +40,7 @@ module.exports = function publish(options = {folder: '.'}, npmArgs = []) {
             run(
               'npm',
               [...npmArgs, 'version', version],
-              Object.assign({}, execOpts, {cwd: path.join(process.cwd(), options.folder)})
+              Object.assign({}, execOpts, {cwd: path.join(process.cwd(), options.dir)})
             )
           )
         }
@@ -51,7 +51,7 @@ module.exports = function publish(options = {folder: '.'}, npmArgs = []) {
           description: `npm publish --tag ${tag}`
         })
       )
-      .then(() => run('npm', [...npmArgs, 'publish', options.folder, '--tag', tag, '--access', 'public'], execOpts))
+      .then(() => run('npm', [...npmArgs, 'publish', options.dir, '--tag', tag, '--access', 'public'], execOpts))
       .then(() =>
         publishStatus(context, {
           state: 'success',

--- a/src/publish.js
+++ b/src/publish.js
@@ -3,7 +3,7 @@ const actionStatus = require('action-status')
 const getContext = require('./context')
 const runDry = require('./run-dry')
 
-module.exports = function publish(options = {}, npmArgs = []) {
+module.exports = function publish(options = {folder: '.'}, npmArgs = []) {
   if (!process.env.NPM_AUTH_TOKEN) {
     throw new Error(`You must set the NPM_AUTH_TOKEN environment variable`)
   }
@@ -44,7 +44,7 @@ module.exports = function publish(options = {}, npmArgs = []) {
           description: `npm publish --tag ${tag}`
         })
       )
-      .then(() => run('npm', [...npmArgs, 'publish', '--tag', tag, '--access', 'public'], execOpts))
+      .then(() => run('npm', [...npmArgs, 'publish', options.folder, '--tag', tag, '--access', 'public'], execOpts))
       .then(() =>
         publishStatus(context, {
           state: 'success',

--- a/src/publish.js
+++ b/src/publish.js
@@ -35,7 +35,10 @@ module.exports = function publish(options = {folder: '.'}, npmArgs = []) {
           return publishStatus(context, {
             state: 'pending',
             description: `npm version ${version}`
-          }).then(() => run('npm', [...npmArgs, 'version', version], execOpts))
+          })
+            .then(() => run('pushd', [options.folder], execOpts))
+            .then(() => run('npm', [...npmArgs, 'version', version], execOpts))
+            .then(() => run('popd', [], execOpts))
         }
       })
       .then(() =>

--- a/src/publish.js
+++ b/src/publish.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const meta = require('github-action-meta')
 const actionStatus = require('action-status')
 const getContext = require('./context')
@@ -35,10 +36,13 @@ module.exports = function publish(options = {folder: '.'}, npmArgs = []) {
           return publishStatus(context, {
             state: 'pending',
             description: `npm version ${version}`
-          })
-            .then(() => run('pushd', [options.folder], execOpts))
-            .then(() => run('npm', [...npmArgs, 'version', version], execOpts))
-            .then(() => run('popd', [], execOpts))
+          }).then(() =>
+            run(
+              'npm',
+              [...npmArgs, 'version', version],
+              Object.assign({}, execOpts, {cwd: path.join(process.cwd(), options.folder)})
+            )
+          )
         }
       })
       .then(() =>


### PR DESCRIPTION
## Problem

The `primer/publish` action currently assumes that the `package.json` of the package to be published is located in the root directory. However, that's not always the case. In the [Docotcat repo](https://github.com/primer/gatsby-theme-primer), we need to publish a package located in `packages/gatsby-theme-doctocat`.  

## Solution

I updated the CLI to accept a `--dir` option, similar to [`npm publish`](https://docs.npmjs.com/cli/publish). The dir option accepts a path to a directory that contains the `package.json` to publish.   If no directory is specified, it defaults to the root directory (i.e. `"."`).

## Alternative solutions

We could hack together a tailored solution for Docotcat using custom scripts. However, since we'll probably be publishing packages in the future that have a similar file structure, it seems best to update `primer/publish` to handle subdirectories.

## Impact

Users can now publish a package located in a subdirectory using the `--dir` option:

<img src="https://user-images.githubusercontent.com/4608155/61148606-ffc8ac80-a493-11e9-920b-d758a9a382ca.png" alt="example action using --folder option" width="400" />

This change will have not impact users publishing packages located in the root directory. `primer/publish` still does not support publishing _multiple_ packages from one repo.
