### PR TITLE
Don’t indicate neutral status with 'exit 78'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This [GitHub Action][github actions] publishes to npm with the following convent
 
 1. If we're on the `master` branch, the `version` field is used as-is and we just run `npm publish --access public`.
    - After publishing a new version on the `master` branch, we tag the commit SHA with `v{version}` via the GitHub API.
-   - If the version in `package.json` is already published, we exit with a `78` code, which is Actions-speak for "neutral".
+   - If the version in `package.json` is already published, we exit with a `0` code. Previously, we exited with a `78` code, which was Actions v1-speak for "neutral", but this has been removed from Actions v2: https://twitter.com/ethomson/status/1163899559279497217?s=20.
 1. If we're on a `release-<version>` branch, we publish a release candidate to the `next` npm dist-tag with the version in the form: `<version>-rc.<sha>`.
    - A [status check][status checks] is created with the context `npm version` noting whether the `version` field in `package.json` matches the `<version>` portion of the branch. If it doesn't, the check's status is marked as pending.
 1. Otherwise, we publish a "canary" release, which has a version in the form: `0.0.0-<sha>`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This [GitHub Action][github actions] publishes to npm with the following convent
 
 1. If we're on the `master` branch, the `version` field is used as-is and we just run `npm publish --access public`.
    - After publishing a new version on the `master` branch, we tag the commit SHA with `v{version}` via the GitHub API.
-   - If the version in `package.json` is already published, we exit with a `0` code. Previously, we exited with a `78` code, which was Actions v1-speak for "neutral", but this has been removed from Actions v2: https://twitter.com/ethomson/status/1163899559279497217?s=20.
+   - If the version in `package.json` is already published, we exit with a `0` code. Previously, we exited with a `78` code, which was Actions v1-speak for "neutral", but this has been [removed from Actions v2](https://twitter.com/ethomson/status/1163899559279497217?s=20).
 1. If we're on a `release-<version>` branch, we publish a release candidate to the `next` npm dist-tag with the version in the form: `<version>-rc.<sha>`.
    - A [status check][status checks] is created with the context `npm version` noting whether the `version` field in `package.json` matches the `<version>` portion of the branch. If it doesn't, the check's status is marked as pending.
 1. Otherwise, we publish a "canary" release, which has a version in the form: `0.0.0-<sha>`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# Actions v1 reported a neutral status when a process exited with a 78 code.
+# Actions v2 removed support for this, so exit with a 0 code instead
+neutral_exit() {
+    EXIT_CODE=$?
+    [[ $EXIT_CODE == "78" ]] && exit 0 || exit $EXIT_CODE
+}
+trap neutral_exit EXIT
+
 # copied directly from:
 # https://github.com/actions/npm/blob/98e6dc1/entrypoint.sh#L5-L13
 if [ -n "$NPM_AUTH_TOKEN" ]; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/publish",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/publish",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Publish Primer projects to npm with GitHub Design Systems conventions",
   "keywords": [
     "primer",


### PR DESCRIPTION
This was removed in Actions v2: https://twitter.com/ethomson/status/1163899559279497217?s=20