### PR TITLE
Registry fix

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ trap neutral_exit EXIT
 if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
   NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
-  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"
+  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-https://registry.npmjs.org}"
 
   # Allow registry.npmjs.org to be overridden with an environment variable
   printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ trap neutral_exit EXIT
 if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
   NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
-  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-https://registry.npmjs.org}"
+  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-"https://registry.npmjs.org"}"
 
   # Allow registry.npmjs.org to be overridden with an environment variable
   printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"


### PR DESCRIPTION
Fixing the default entry point.

It still works without the `https://`, but it spams the logs with warnings.

```
npm WARN invalid config registry="registry.npmjs.org"
npm WARN invalid config Must be a full url with 'http://'
```

NOTE: I have not tested running this