### PR TITLE
Remove leading back slashes in registry url

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ trap neutral_exit EXIT
 if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
   NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
-  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-"https://registry.npmjs.org"}"
+  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"
 
   # Allow registry.npmjs.org to be overridden with an environment variable
   printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"


### PR DESCRIPTION
[This recent change](https://github.com/primer/publish/pull/25) to the npm registry url causes a `npm ERR! 401 Unauthorized - PUT https://registry.npmjs.org/<package-name> - You must be logged in to publish packages.`.

Although the npm registry url looks correct in the error, I think that the leading back slashes should have been removed.