### PR TITLE
Use any branch as the default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ It's possible to pass additional arguments to `npm` via the `npm_args` input in 
 - name: Publish to the npm registry
   uses: "primer/publish"
   with:
-    npm_args: "-unsafe-perm --allow-same-version"
+    npm_args: "--unsafe-perm --allow-same-version"
 ```
 
 ### `release_branch`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can pass additional [inputs](#inputs) via the `with` key:
   uses: "primer/publish@v3"
   with:
     npm-args: "--unsafe-perm --allow-same-version"
-    release-branch: "main"
+    default-branch: "main"
 ```
 
 
@@ -91,7 +91,7 @@ It's possible to pass additional arguments to `npm` via the `npm_args` input in 
     npm_args: "--unsafe-perm --allow-same-version"
 ```
 
-### `release_branch`
+### `default_branch`
 
 The branch you'd like to use to trigger releases. Typically this is `main` or `master`.
 
@@ -101,7 +101,7 @@ Default: `master`
 - name: Publish to the npm registry
   uses: "primer/publish@v3"
   with:
-    release_branch: "main"
+    default_branch: "main"
 ```
 
 ### `release_tag`

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This [GitHub Action][github actions] publishes to npm with the following conventions:
 
-1. If we're on the `master` branch, the `version` field is used as-is and we just run `npm publish --access public`.
-   - After publishing a new version on the `master` branch, we tag the commit SHA with `v{version}` via the GitHub API.
+1. If we're on the default branch, the `version` field is used as-is and we just run `npm publish --access public`.
+   - After publishing a new version on the default branch, we tag the commit SHA with `v{version}` via the GitHub API.
    - If the version in `package.json` is already published, we exit with a `0` code. Previously, we exited with a `78` code, which was Actions v1-speak for "neutral", but this has been [removed from Actions v2](https://twitter.com/ethomson/status/1163899559279497217?s=20).
 1. If we're on a `release-<version>` branch, we publish a release candidate to the `next` npm dist-tag with the version in the form: `<version>-rc.<sha>`.
    - A [status check][status checks] is created with the context `npm version` noting whether the `version` field in `package.json` matches the `<version>` portion of the branch. If it doesn't, the check's status is marked as pending.
@@ -26,8 +26,8 @@ If you're on a release branch (`release-<version>`) and the `<version>` portion 
 We suggest that you place this action after any linting and/or testing actions to catch as many errors as possible before publishing.
 
 
-### Actions v2
-To use this in an [Actions v2](https://help.github.com/en/articles/migrating-github-actions-from-hcl-syntax-to-yaml-syntax) workflow, add the following YAML to one or more of your steps:
+### Actions
+To use this in an Actions workflow, add the following YAML to one or more of your steps:
 
 ```yaml
 - uses: primer/publish@master
@@ -36,71 +36,85 @@ To use this in an [Actions v2](https://help.github.com/en/articles/migrating-git
     NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 ```
 
-You can pass additional [options](#options) via the `args` key:
-
-```diff
-​- uses: primer/publish@master
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-+   args: '--dry-run -- --unsafe-perm'
-```
-
-### Actions v1
-To use this in an Actions v1 workflow, add the following snippet to `.github/main.workflow`:
+You can pass additional [inputs](#inputs) via the `with` key:
 
 ```hcl
-action "publish" {
-  uses = "primer/publish@master"
-  secrets = [
-    "GITHUB_TOKEN",
-    "NPM_AUTH_TOKEN",
-  ]
-}
+- name: Publish to the npm registry
+  uses: "primer/publish@dbf72c725e7eb6309aee73215e4fbcbe2b9c48f8"
+  with:
+    npm-args: "--unsafe-perm --allow-same-version"
+    release-branch: "main"
 ```
 
-## Options
 
-### `--dry-run`
+## Inputs
 
-Default: `false`
+### `dry_run`
 
 Does everything publish would do except actually publishing to the registry. Reports the details of what would have been published.
 
+Default: `false`
+
 #### Example
 
 ```hcl
-action "publish" {
-  uses = "primer/publish@master"
-  secrets = ["GITHUB_TOKEN", "NPM_AUTH_TOKEN"]
-  args = "--dry-run"
-}
+- name: Publish to the npm registry
+  uses: "primer/publish"
+  with:
+    dry_run: true
 ```
 
-### `--dir=<path>`
-
-Default: `.`
+### `dir`
 
 Accepts a path to the directory that contains the `package.json` to publish.
 
+Default: `.`
+
 #### Example
 
 ```hcl
-action "publish" {
-  uses = "primer/publish@master"
-  secrets = ["GITHUB_TOKEN", "NPM_AUTH_TOKEN"]
-  args = "--dir=packages/example"
+- name: Publish to the npm registry
+  uses: "primer/publish"
+  with:
+    dir: "packages/example"
 }
 ```
 
-## npm CLI arguments
+### `npm_args`
 
-It's possible to pass additional arguments to `npm` via the `args` field in your workflow action. Because the `primer-publish` CLI accepts options of its own (such as `--dry-run`), you need to prefix any `npm` arguments with `--`:
+It's possible to pass additional arguments to `npm` via the `npm_args` input in your workflow action.
 
-```diff
-action "publish" {
-  uses = "primer/publish@master"
-+  args = ["--", "--registry=https://registry.your.org"]
+```hcl
+- name: Publish to the npm registry
+  uses: "primer/publish"
+  with:
+    npm_args: "-unsafe-perm --allow-same-version"
+```
+
+### `release_branch`
+
+The branch you'd like to use to trigger releases. Typically this is `main` or `master`.
+
+Default: `master`
+
+```hcl
+- name: Publish to the npm registry
+  uses: "primer/publish"
+  with:
+    release_branch: "main"
+```
+
+### `release_tag`
+
+The `release_tag` input can be used to override the auto-generated release tag.
+
+Default: `latest`
+
+```hcl
+- name: Publish to the npm registry
+  uses: "primer/publish"
+  with:
+    release_tag: "1.0.0"
 ```
 
 [github actions]: https://github.com/features/actions

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We suggest that you place this action after any linting and/or testing actions t
 To use this in an Actions workflow, add the following YAML to one or more of your steps:
 
 ```yaml
-- uses: primer/publish@master
+- uses: primer/publish@v3
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
@@ -40,7 +40,7 @@ You can pass additional [inputs](#inputs) via the `with` key:
 
 ```hcl
 - name: Publish to the npm registry
-  uses: "primer/publish@dbf72c725e7eb6309aee73215e4fbcbe2b9c48f8"
+  uses: "primer/publish@v3"
   with:
     npm-args: "--unsafe-perm --allow-same-version"
     release-branch: "main"
@@ -59,7 +59,7 @@ Default: `false`
 
 ```hcl
 - name: Publish to the npm registry
-  uses: "primer/publish"
+  uses: "primer/publish@v3"
   with:
     dry_run: true
 ```
@@ -74,7 +74,7 @@ Default: `.`
 
 ```hcl
 - name: Publish to the npm registry
-  uses: "primer/publish"
+  uses: "primer/publish@v3"
   with:
     dir: "packages/example"
 }
@@ -86,7 +86,7 @@ It's possible to pass additional arguments to `npm` via the `npm_args` input in 
 
 ```hcl
 - name: Publish to the npm registry
-  uses: "primer/publish"
+  uses: "primer/publish@v3"
   with:
     npm_args: "--unsafe-perm --allow-same-version"
 ```
@@ -99,7 +99,7 @@ Default: `master`
 
 ```hcl
 - name: Publish to the npm registry
-  uses: "primer/publish"
+  uses: "primer/publish@v3"
   with:
     release_branch: "main"
 ```
@@ -112,7 +112,7 @@ Default: `latest`
 
 ```hcl
 - name: Publish to the npm registry
-  uses: "primer/publish"
+  uses: "primer/publish@v3"
   with:
     release_tag: "1.0.0"
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: '@primer/publish'
 description: 'Publish Primer projects to npm with GitHub Design Systems conventions'
 inputs:
-  release_branch:
+  default_branch:
     description: 'Branch that releases should be cut from (usually your default branch)'
     required: false
   dir:

--- a/action.yml
+++ b/action.yml
@@ -1,19 +1,19 @@
 name: '@primer/publish'
 description: 'Publish Primer projects to npm with GitHub Design Systems conventions'
 inputs:
-  releaseBranch:
+  release_branch:
     description: 'Branch that releases should be cut from (usually your default branch)'
     required: false
   dir:
     description: "directory to find package.json in"
     required: false
-  dryRun:
+  dry_run:
     description: "run action without publishing"
     required: false
-  npmArgs:
+  npm_args:
     description: "publish options & additional npm cli arguments"
     required: false
-  releaseTag:
+  release_tag:
     description: 'Override tag to release package with'
     required: false
     default: 'latest'

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,25 @@
 name: '@primer/publish'
 description: 'Publish Primer projects to npm with GitHub Design Systems conventions'
 inputs:
+  dir:
+    description: "directory to find package.json in"
+    required: false
+  dry-run:
+    description: "run action without publishing"
+    required: false
+  npm-args:
+    description: "publish options & additional npm cli arguments"
+    required: false
   release-branch:
     description: 'Branch that releases should be cut from (usually your default branch)'
     required: false
     default: 'master'
+  release-tag:
+    description: 'Override tag to release package with'
+    required: false
+    default: 'latest'
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{inputs.npm-args}}

--- a/action.yml
+++ b/action.yml
@@ -22,3 +22,4 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{inputs.npm-args}}
+    - ${{inputs.release-branch}}

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: '@primer/publish'
 description: 'Publish Primer projects to npm with GitHub Design Systems conventions'
 inputs:
+  release-branch:
+    description: 'Branch that releases should be cut from (usually your default branch)'
+    required: false
   dir:
     description: "directory to find package.json in"
     required: false
@@ -9,9 +12,6 @@ inputs:
     required: false
   npm-args:
     description: "publish options & additional npm cli arguments"
-    required: false
-  release-branch:
-    description: 'Branch that releases should be cut from (usually your default branch)'
     required: false
   release-tag:
     description: 'Override tag to release package with'

--- a/action.yml
+++ b/action.yml
@@ -20,3 +20,5 @@ inputs:
 runs:
   using: 'docker'
   image: 'Dockerfile'
+  args:
+    - ${{inputs.npm_args}}

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,10 @@
+name: '@primer/publish'
+description: 'Publish Primer projects to npm with GitHub Design Systems conventions'
+inputs:
+  release-branch:
+    description: 'Branch that releases should be cut from (usually your default branch)'
+    required: false
+    default: 'master'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -1,25 +1,22 @@
 name: '@primer/publish'
 description: 'Publish Primer projects to npm with GitHub Design Systems conventions'
 inputs:
-  release-branch:
+  releaseBranch:
     description: 'Branch that releases should be cut from (usually your default branch)'
     required: false
   dir:
     description: "directory to find package.json in"
     required: false
-  dry-run:
+  dryRun:
     description: "run action without publishing"
     required: false
-  npm-args:
+  npmArgs:
     description: "publish options & additional npm cli arguments"
     required: false
-  release-tag:
+  releaseTag:
     description: 'Override tag to release package with'
     required: false
     default: 'latest'
 runs:
   using: 'docker'
   image: 'Dockerfile'
-  args:
-    - ${{inputs.npm-args}}
-    - ${{inputs.release-branch}}

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,6 @@ inputs:
   release-branch:
     description: 'Branch that releases should be cut from (usually your default branch)'
     required: false
-    default: 'master'
   release-tag:
     description: 'Override tag to release package with'
     required: false

--- a/cli.js
+++ b/cli.js
@@ -21,13 +21,12 @@ if (options.help) {
 }
 
 const npmArgs = options._
-const releaseBranch = options.releaseBranch || "master"
 delete options._
 
 console.warn(`[publish] options: ${JSON.stringify(options, null, 2)}`)
 console.warn(`[publish] npm args: ${JSON.stringify(npmArgs, null, 2)}`)
 
-publish(options, npmArgs, releaseBranch)
+publish(options, npmArgs)
   .then(context => {
     console.warn(`published! ${JSON.stringify(context, null, 2)}`)
   })

--- a/cli.js
+++ b/cli.js
@@ -21,12 +21,13 @@ if (options.help) {
 }
 
 const npmArgs = options._
+const releaseBranch = options.releaseBranch || "master"
 delete options._
 
 console.warn(`[publish] options: ${JSON.stringify(options, null, 2)}`)
 console.warn(`[publish] npm args: ${JSON.stringify(npmArgs, null, 2)}`)
 
-publish(options, npmArgs)
+publish(options, npmArgs, releaseBranch)
   .then(context => {
     console.warn(`published! ${JSON.stringify(context, null, 2)}`)
   })

--- a/cli.js
+++ b/cli.js
@@ -12,10 +12,10 @@ const yargs = require('yargs')
     type: 'string',
     default: process.env.INPUT_DIR || '.'
   })
-  .option('release-branch', {
+  .option('default-branch', {
     describe: 'Default branch to use for merge releases',
     type: 'string',
-    default: process.env.INPUT_RELEASE_BRANCH || 'master'
+    default: process.env.INPUT_DEFAULT_BRANCH || 'master'
   })
   .option('release-tag', {
     describe: 'Override tag to release package with',

--- a/cli.js
+++ b/cli.js
@@ -4,12 +4,23 @@ const publish = require('./src/publish')
 const yargs = require('yargs')
   .option('dry-run', {
     describe: 'Print what will be done without doing it',
+    default: process.env.INPUT_DRY_RUN || false,
     type: 'boolean'
   })
   .option('dir', {
     describe: 'Path to the directory that contains the package.json to publish',
     type: 'string',
-    default: '.'
+    default: process.env.INPUT_DIR || '.'
+  })
+  .option('release-branch', {
+    describe: 'Default branch to use for merge releases',
+    type: 'string',
+    default: process.env.INPUT_RELEASE_BRANCH || 'master'
+  })
+  .option('release-tag', {
+    describe: 'Override tag to release package with',
+    type: 'string',
+    default: process.env.INPUT_RELEASE_TAG || 'latest'
   })
   .alias('help', 'h')
 

--- a/cli.js
+++ b/cli.js
@@ -25,6 +25,7 @@ const yargs = require('yargs')
   .alias('help', 'h')
 
 const options = yargs.argv
+console.log('yargs release branch:🐬🐬', options.releaseBranch, process.env.INPUT_RELEASE_BRANCH, process.env)
 
 if (options.help) {
   yargs.showHelp()

--- a/cli.js
+++ b/cli.js
@@ -25,7 +25,6 @@ const yargs = require('yargs')
   .alias('help', 'h')
 
 const options = yargs.argv
-console.log('yargs release branch:🐬🐬', options.releaseBranch, process.env.INPUT_RELEASE_BRANCH, process.env)
 
 if (options.help) {
   yargs.showHelp()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,4 +27,4 @@ git config --global user.name "${GIT_USER_NAME:-$(jq -r .pusher.name $GITHUB_EVE
 # then print out our config
 git config --list
 
-sh -c "/primer-publish/cli.js $*"
+sh -c "/primer-publish/cli.js -- $*"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
 
   # Allow registry.npmjs.org to be overridden with an environment variable
   printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
+  cat "$NPM_CONFIG_USERCONFIG"
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ trap neutral_exit EXIT
 if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
   NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
-  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-"https://registry.npmjs.org"}"
+  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-"registry.npmjs.org"}"
 
   # Allow registry.npmjs.org to be overridden with an environment variable
   printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,6 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
 
   # Allow registry.npmjs.org to be overridden with an environment variable
   printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
-  cat "$NPM_CONFIG_USERCONFIG"
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
 fi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/publish",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Publish Primer projects to npm with GitHub Design Systems conventions",
   "keywords": [
     "primer",

--- a/src/context.js
+++ b/src/context.js
@@ -2,7 +2,7 @@ const path = require('path')
 const meta = require('github-action-meta')
 const readJSON = require('./read-json')
 
-const DEFAULT_BRANCH_PATTERN = /^release-(.+)$/
+const RELEASE_BRANCH_PATTERN = /^release-(.+)$/
 const RELEASE_CANDIDATE_PREID = 'rc'
 const RELEASE_CANDIDATE_TAG = 'next'
 
@@ -35,7 +35,7 @@ module.exports = function getContext({dir, defaultBranch, releaseTag} = {}) {
   } else {
     let match
     const shortSha = sha.substr(0, 7)
-    if ((match = branch.match(DEFAULT_BRANCH_PATTERN))) {
+    if ((match = branch.match(RELEASE_BRANCH_PATTERN))) {
       const v = match[1]
       status = Object.assign(
         {

--- a/src/context.js
+++ b/src/context.js
@@ -26,7 +26,8 @@ module.exports = function getContext({dir = '.'} = {}) {
   }
 
   const config = packageJson[CONFIG_KEY] || {}
-  const {releaseBranch = 'master', releaseTag = 'latest'} = config
+  const {releaseTag = 'latest'} = config
+  const releaseBranch = process.env.INPUTS_RELEASE_BRANCH || "master"
 
   let version
   let status

--- a/src/context.js
+++ b/src/context.js
@@ -2,7 +2,7 @@ const path = require('path')
 const meta = require('github-action-meta')
 const readJSON = require('./read-json')
 
-const RELEASE_BRANCH_PATTERN = /^release-(.+)$/
+const DEFAULT_BRANCH_PATTERN = /^release-(.+)$/
 const RELEASE_CANDIDATE_PREID = 'rc'
 const RELEASE_CANDIDATE_TAG = 'next'
 
@@ -35,7 +35,7 @@ module.exports = function getContext({dir, releaseBranch, releaseTag} = {}) {
   } else {
     let match
     const shortSha = sha.substr(0, 7)
-    if ((match = branch.match(RELEASE_BRANCH_PATTERN))) {
+    if ((match = branch.match(DEFAULT_BRANCH_PATTERN))) {
       const v = match[1]
       status = Object.assign(
         {

--- a/src/context.js
+++ b/src/context.js
@@ -62,5 +62,5 @@ module.exports = function getContext({dir, releaseBranch, releaseTag} = {}) {
     }
   }
 
-  return Promise.resolve({name, version, tag, config, packageJson, status})
+  return Promise.resolve({name, version, tag, packageJson, status})
 }

--- a/src/context.js
+++ b/src/context.js
@@ -29,7 +29,7 @@ module.exports = function getContext({dir, releaseBranch, releaseTag} = {}) {
 
   const {sha, branch} = meta.git
   const repo = meta.repo.toString()
-
+  console.log('🌈 release branch:', releaseBranch, `branch:`, branch)
   if (branch === releaseBranch) {
     version = packageJson.version
   } else {

--- a/src/context.js
+++ b/src/context.js
@@ -11,7 +11,7 @@ const RELEASE_CANDIDATE_TAG = 'next'
 const CANARY_VERSION = '0.0.0'
 const CANARY_TAG = 'canary'
 
-module.exports = function getContext({dir = '.'} = {}) {
+module.exports = function getContext({dir = '.', releaseBranch} = {}) {
   const packageJson = readJSON(path.join(dir, 'package.json'))
   if (!packageJson) {
     throw new Error(`Unable to read package.json in ${path.join(process.cwd(), dir)}!`)
@@ -26,8 +26,7 @@ module.exports = function getContext({dir = '.'} = {}) {
   }
 
   const config = packageJson[CONFIG_KEY] || {}
-  const {releaseBranch = 'master', releaseTag = 'latest'} = config
-
+  const {releaseTag = 'latest'} = config
   let version
   let status
   let tag = releaseTag

--- a/src/context.js
+++ b/src/context.js
@@ -2,8 +2,6 @@ const path = require('path')
 const meta = require('github-action-meta')
 const readJSON = require('./read-json')
 
-const CONFIG_KEY = '@primer/publish'
-
 const RELEASE_BRANCH_PATTERN = /^release-(.+)$/
 const RELEASE_CANDIDATE_PREID = 'rc'
 const RELEASE_CANDIDATE_TAG = 'next'
@@ -11,7 +9,7 @@ const RELEASE_CANDIDATE_TAG = 'next'
 const CANARY_VERSION = '0.0.0'
 const CANARY_TAG = 'canary'
 
-module.exports = function getContext({dir = '.'} = {}) {
+module.exports = function getContext({dir, releaseBranch, releaseTag} = {}) {
   const packageJson = readJSON(path.join(dir, 'package.json'))
   if (!packageJson) {
     throw new Error(`Unable to read package.json in ${path.join(process.cwd(), dir)}!`)
@@ -24,10 +22,6 @@ module.exports = function getContext({dir = '.'} = {}) {
   } else if (!name) {
     throw new Error(`package.json is missing a "name" field`)
   }
-
-  const config = packageJson[CONFIG_KEY] || {}
-  const {releaseTag = 'latest'} = config
-  const releaseBranch = process.env.INPUTS_RELEASE_BRANCH || "master"
 
   let version
   let status

--- a/src/context.js
+++ b/src/context.js
@@ -29,7 +29,7 @@ module.exports = function getContext({dir, releaseBranch, releaseTag} = {}) {
 
   const {sha, branch} = meta.git
   const repo = meta.repo.toString()
-  console.log('🌈 release branch:', releaseBranch, `branch:`, branch)
+
   if (branch === releaseBranch) {
     version = packageJson.version
   } else {

--- a/src/context.js
+++ b/src/context.js
@@ -9,7 +9,7 @@ const RELEASE_CANDIDATE_TAG = 'next'
 const CANARY_VERSION = '0.0.0'
 const CANARY_TAG = 'canary'
 
-module.exports = function getContext({dir, releaseBranch, releaseTag} = {}) {
+module.exports = function getContext({dir, defaultBranch, releaseTag} = {}) {
   const packageJson = readJSON(path.join(dir, 'package.json'))
   if (!packageJson) {
     throw new Error(`Unable to read package.json in ${path.join(process.cwd(), dir)}!`)
@@ -30,7 +30,7 @@ module.exports = function getContext({dir, releaseBranch, releaseTag} = {}) {
   const {sha, branch} = meta.git
   const repo = meta.repo.toString()
 
-  if (branch === releaseBranch) {
+  if (branch === defaultBranch) {
     version = packageJson.version
   } else {
     let match

--- a/src/context.js
+++ b/src/context.js
@@ -11,7 +11,7 @@ const RELEASE_CANDIDATE_TAG = 'next'
 const CANARY_VERSION = '0.0.0'
 const CANARY_TAG = 'canary'
 
-module.exports = function getContext({dir = '.', releaseBranch} = {}) {
+module.exports = function getContext({dir = '.'} = {}) {
   const packageJson = readJSON(path.join(dir, 'package.json'))
   if (!packageJson) {
     throw new Error(`Unable to read package.json in ${path.join(process.cwd(), dir)}!`)
@@ -26,7 +26,8 @@ module.exports = function getContext({dir = '.', releaseBranch} = {}) {
   }
 
   const config = packageJson[CONFIG_KEY] || {}
-  const {releaseTag = 'latest'} = config
+  const {releaseBranch = 'master', releaseTag = 'latest'} = config
+
   let version
   let status
   let tag = releaseTag

--- a/src/publish.js
+++ b/src/publish.js
@@ -52,6 +52,7 @@ module.exports = function publish(options = {dir: '.'}, npmArgs = []) {
         })
       )
       .then(() => run('npm', [...npmArgs, 'publish', options.dir, '--tag', tag, '--access', 'public'], execOpts))
+      .then(() => run("node", ["--version"])
       .then(() =>
         publishStatus(context, {
           state: 'success',

--- a/src/publish.js
+++ b/src/publish.js
@@ -52,7 +52,7 @@ module.exports = function publish(options = {dir: '.'}, npmArgs = []) {
         })
       )
       .then(() => run('npm', [...npmArgs, 'publish', options.dir, '--tag', tag, '--access', 'public'], execOpts))
-      .then(() => run("node", ["--version"], execOpts)
+      .then(() => run("node", ["--version"], execOpts))
       .then(() =>
         publishStatus(context, {
           state: 'success',

--- a/src/publish.js
+++ b/src/publish.js
@@ -4,7 +4,7 @@ const actionStatus = require('action-status')
 const getContext = require('./context')
 const runDry = require('./run-dry')
 
-module.exports = function publish(options = {dir: '.'}, npmArgs = []) {
+module.exports = function publish(options = {dir: '.'}, releaseBranch, npmArgs = []) {
   if (!process.env.NPM_AUTH_TOKEN) {
     throw new Error(`You must set the NPM_AUTH_TOKEN environment variable`)
   }
@@ -12,7 +12,7 @@ module.exports = function publish(options = {dir: '.'}, npmArgs = []) {
   const run = options.dryRun ? runDry : require('execa')
   const execOpts = {stdio: 'inherit'}
 
-  return getContext(options).then(context => {
+  return getContext(options, releaseBranch).then(context => {
     const {name, version, tag, packageJson} = context
     const {sha} = meta.git
 

--- a/src/publish.js
+++ b/src/publish.js
@@ -52,7 +52,6 @@ module.exports = function publish(options = {dir: '.'}, npmArgs = []) {
         })
       )
       .then(() => run('npm', [...npmArgs, 'publish', options.dir, '--tag', tag, '--access', 'public'], execOpts))
-      .then(() => run("node", ["--version"], execOpts))
       .then(() =>
         publishStatus(context, {
           state: 'success',

--- a/src/publish.js
+++ b/src/publish.js
@@ -52,7 +52,7 @@ module.exports = function publish(options = {dir: '.'}, npmArgs = []) {
         })
       )
       .then(() => run('npm', [...npmArgs, 'publish', options.dir, '--tag', tag, '--access', 'public'], execOpts))
-      .then(() => run("node", ["--version"])
+      .then(() => run("node", ["--version"], execOpts)
       .then(() =>
         publishStatus(context, {
           state: 'success',

--- a/src/publish.js
+++ b/src/publish.js
@@ -4,7 +4,7 @@ const actionStatus = require('action-status')
 const getContext = require('./context')
 const runDry = require('./run-dry')
 
-module.exports = function publish(options = {dir: '.'}, releaseBranch, npmArgs = []) {
+module.exports = function publish(options = {dir: '.'}, npmArgs = []) {
   if (!process.env.NPM_AUTH_TOKEN) {
     throw new Error(`You must set the NPM_AUTH_TOKEN environment variable`)
   }
@@ -12,7 +12,7 @@ module.exports = function publish(options = {dir: '.'}, releaseBranch, npmArgs =
   const run = options.dryRun ? runDry : require('execa')
   const execOpts = {stdio: 'inherit'}
 
-  return getContext(options, releaseBranch).then(context => {
+  return getContext(options).then(context => {
     const {name, version, tag, packageJson} = context
     const {sha} = meta.git
 


### PR DESCRIPTION
This PR updates the publish action to use any branch as the default branch instead of assuming the default is `master`. I've also made some refactors to update us to the latest & greatest Actions syntax using a `action.yml` metadata file and inputs for each argument instead of a catchall argument string.

Tested in [Primer Components](https://github.com/primer/components/pull/862/checks?check_run_id=1042985738) and in a [test repo](https://github.com/emplums/test-package/actions)

🚨 This includes the following breaking changes:
- instead of using `args` in the `env` section of your workflow file, all arguments are separated into individual [Actions inputs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepswith). See the [updated README](https://github.com/primer/publish/pull/32/files#diff-04c6e90faac2675aa89e2176d2eec7d8) for more details on each input.